### PR TITLE
Add dev build for side-by-side usage

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - run: chmod +x gradlew
 
       - name: Validate
-        run: ./gradlew lint test assembleDebug --quiet
+        run: ./gradlew lint test assembleDebug assembleDevRelease --quiet
 
   beta_release:
     runs-on: ubuntu-latest
@@ -76,10 +76,11 @@ jobs:
         run: >
           ./gradlew
           assertReleaseSigningConfigured
-          assembleRelease
+          assemblePublicRelease
           -PciVersionName=${{ steps.version.outputs.version_name }}
           -PciVersionCode=${{ github.run_number }}
           -PreleaseApkName=ni-launcher-beta.apk
+          -PuseReleaseSigning=true
           --quiet
         env:
           RELEASE_STORE_FILE: ${{ github.workspace }}/release.keystore
@@ -101,7 +102,7 @@ jobs:
           name: Ni Launcher ${{ steps.version.outputs.version_name }}
           prerelease: true
           generate_release_notes: true
-          files: app/build/outputs/apk/release/ni-launcher-beta.apk
+          files: app/build/outputs/apk/public/release/ni-launcher-beta.apk
 
   stable_release:
     runs-on: ubuntu-latest
@@ -140,10 +141,11 @@ jobs:
         run: >
           ./gradlew
           assertReleaseSigningConfigured
-          assembleRelease
+          assemblePublicRelease
           -PciVersionName=${{ steps.base_version.outputs.base_version }}
           -PciVersionCode=${{ github.run_number }}
           -PreleaseApkName=ni-launcher-release.apk
+          -PuseReleaseSigning=true
           --quiet
         env:
           RELEASE_STORE_FILE: ${{ github.workspace }}/release.keystore
@@ -154,5 +156,5 @@ jobs:
       - name: Publish stable release
         uses: softprops/action-gh-release@v2
         with:
-          files: app/build/outputs/apk/release/ni-launcher-release.apk
+          files: app/build/outputs/apk/public/release/ni-launcher-release.apk
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Ni-Launcher is a fast, minimal Android launcher focused on reducing distractions
 ### Beta APK
 Beta builds are published from merges to `main` as GitHub prereleases.
 
+### Local Development
+Local side-by-side development builds use the `com.ni.launcher.dev` application id and install as `Ni-Launcher Dev`, so you can keep the public app installed from Obtainium while testing local changes.
+
 ### Obtainium
 For automated updates via [Obtainium](https://github.com/ImranR98/Obtainium), add this repository URL:
 `https://github.com/Dovonun/android-launcher`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,9 @@ val ciVersionName = providers.gradleProperty("ciVersionName").orElse(appVersionB
 val ciVersionCode = providers.gradleProperty("ciVersionCode").orElse("1").map(String::toInt)
 val releaseApkName = providers.gradleProperty("releaseApkName").orElse("ni-launcher-release.apk")
 val releaseStoreFilePath = System.getenv("RELEASE_STORE_FILE")
+val useReleaseSigning = providers.gradleProperty("useReleaseSigning")
+    .orElse(if (releaseStoreFilePath.isNullOrBlank()) "false" else "true")
+    .map(String::toBoolean)
 
 android {
     namespace = "com.ni.launcher"
@@ -44,7 +47,22 @@ android {
         }
     }
 
+    flavorDimensions += "edition"
+    productFlavors {
+        create("public") {
+            dimension = "edition"
+        }
+        create("dev") {
+            dimension = "edition"
+            applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
+        }
+    }
+
     buildTypes {
+        debug {
+            versionNameSuffix = "${versionNameSuffix ?: ""}-debug"
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true
@@ -52,8 +70,12 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release").takeIf {
-                !releaseStoreFilePath.isNullOrBlank()
+            signingConfig = if (useReleaseSigning.get()) {
+                signingConfigs.getByName("release").takeIf {
+                    !releaseStoreFilePath.isNullOrBlank()
+                }
+            } else {
+                signingConfigs.getByName("debug")
             }
         }
     }
@@ -78,8 +100,13 @@ android {
 
 android.applicationVariants.configureEach {
     outputs.configureEach {
-        if (buildType.name == "release") {
-            (this as BaseVariantOutputImpl).outputFileName = releaseApkName.get()
+        val output = this as BaseVariantOutputImpl
+        output.outputFileName = when {
+            flavorName == "public" && buildType.name == "release" -> releaseApkName.get()
+            flavorName == "dev" && buildType.name == "release" -> "ni-launcher-dev-release.apk"
+            flavorName == "dev" && buildType.name == "debug" -> "ni-launcher-dev-debug.apk"
+            flavorName == "public" && buildType.name == "debug" -> "ni-launcher-public-debug.apk"
+            else -> output.outputFileName
         }
     }
 }


### PR DESCRIPTION
This adds a build variant that builds with a "dev" suffix to make allow both the dev and the release versions to be installed on the same device side-by-side.